### PR TITLE
feat: 在 git-committers 插件中启用 CI 环境的判断，避免触发 GitHub API 请求限制

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ plugins:
       enable_creation_date: true
       type: timeago
   - git-committers:
+      enabled: !ENV [CI, false] # 仅在 CI 环境下启用
       repository: Ac-Wiki/AcWiKi
       branch: main
       token: !ENV GITHUB_TOKEN


### PR DESCRIPTION
如需在本地开发中预览插件效果，将变量`CI`设为`true`即可。

```bash
CI=true mkdocs serve
```

参考链接：https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#+git-committers.enabled